### PR TITLE
Fix markdown widget content update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,7 +118,7 @@ function AppContent() {
     if (widget) {
       updateWidget({
         ...widget,
-        content: updates.content || widget.content
+        content: updates.content ?? widget.content
       })
     }
   }


### PR DESCRIPTION
## Summary
- fix markdown note updates to allow saving empty content

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684181b215dc8329b249bfd23be96ec0