### PR TITLE
Add Jest setup with layout util tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,8 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "jest"
   },
   "dependencies": {
     "@hello-pangea/dnd": "^17.0.0",
@@ -36,6 +37,11 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.6.2",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.2.2",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,0 +1,27 @@
+import { findNextPosition, HEADER_HEIGHT, HEADER_MARGIN, GRID_ROW_HEIGHT } from './utils/layout'
+
+describe('findNextPosition', () => {
+  const headerGridUnits = Math.ceil((HEADER_HEIGHT + HEADER_MARGIN) / GRID_ROW_HEIGHT)
+
+  it('returns start position when widget list is empty', () => {
+    const pos = findNextPosition([], true, 4, 4)
+    expect(pos).toEqual({ x: 0, y: headerGridUnits })
+  })
+
+  it('places widget in same row if space is available', () => {
+    const widgets = [
+      { position: { x: 0, y: 0 }, size: { width: 4, height: 4 } }
+    ]
+    const pos = findNextPosition(widgets, false, 4, 4)
+    expect(pos).toEqual({ x: 4, y: 0 })
+  })
+
+  it('starts a new row when current row is full', () => {
+    const widgets = [
+      { position: { x: 0, y: 0 }, size: { width: 6, height: 4 } },
+      { position: { x: 6, y: 0 }, size: { width: 6, height: 4 } }
+    ]
+    const pos = findNextPosition(widgets, false, 4, 4)
+    expect(pos).toEqual({ x: 0, y: 4 })
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,13 +13,16 @@ import { ThemeProvider, useTheme } from './contexts/ThemeContext'
 import { SpotifyProvider } from './contexts/SpotifyContext'
 import { CanvasProvider, useCanvas } from './contexts/CanvasContext'
 import { CommandPalette } from './components/common/CommandPalette'
+import {
+  HEADER_HEIGHT,
+  GRID_COLS,
+  GRID_ROW_HEIGHT,
+  HEADER_MARGIN,
+  findNextPosition as calculateNextPosition,
+} from './utils/layout'
 
 const GridLayout = WidthProvider(Responsive)
 
-const HEADER_HEIGHT = 75
-const GRID_COLS = 12
-const GRID_ROW_HEIGHT = 50
-const HEADER_MARGIN = 5
 
 // Helper function to convert Widget to Layout
 const widgetToLayout = (widget: Widget): Layout => ({
@@ -57,25 +60,7 @@ function AppContent() {
 
   // Calculate the next available position for a new widget
   const findNextPosition = (width: number, height: number) => {
-    const headerGridUnits = showHeaderImage ? Math.ceil((HEADER_HEIGHT + HEADER_MARGIN) / GRID_ROW_HEIGHT) : 0
-    
-    if (widgets.length === 0) {
-      return { x: 0, y: headerGridUnits }
-    }
-
-    // Try to find space in the current row first
-    const currentRowY = Math.max(...widgets.map(item => item.position.y))
-    const itemsInCurrentRow = widgets.filter(item => item.position.y === currentRowY)
-    const lastItemInRow = itemsInCurrentRow[itemsInCurrentRow.length - 1]
-    
-    if (lastItemInRow && (lastItemInRow.position.x + lastItemInRow.size.width + width) <= GRID_COLS) {
-      // There's space in the current row
-      return { x: lastItemInRow.position.x + lastItemInRow.size.width, y: currentRowY }
-    }
-
-    // Start a new row
-    const maxY = Math.max(...widgets.map(item => item.position.y + item.size.height))
-    return { x: 0, y: Math.max(maxY, headerGridUnits) }
+    return calculateNextPosition(widgets, showHeaderImage, width, height)
   }
 
   const addWidget = (type: Widget['widget_type']) => {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,0 +1,40 @@
+export const HEADER_HEIGHT = 75
+export const GRID_COLS = 12
+export const GRID_ROW_HEIGHT = 50
+export const HEADER_MARGIN = 5
+
+export interface WidgetInfo {
+  position: { x: number; y: number }
+  size: { width: number; height: number }
+}
+
+export const findNextPosition = (
+  widgets: WidgetInfo[],
+  showHeaderImage: boolean,
+  width: number,
+  height: number
+) => {
+  const headerGridUnits = showHeaderImage
+    ? Math.ceil((HEADER_HEIGHT + HEADER_MARGIN) / GRID_ROW_HEIGHT)
+    : 0
+
+  if (widgets.length === 0) {
+    return { x: 0, y: headerGridUnits }
+  }
+
+  const currentRowY = Math.max(...widgets.map((item) => item.position.y))
+  const itemsInCurrentRow = widgets.filter((item) => item.position.y === currentRowY)
+  const lastItemInRow = itemsInCurrentRow[itemsInCurrentRow.length - 1]
+
+  if (
+    lastItemInRow &&
+    lastItemInRow.position.x + lastItemInRow.size.width + width <= GRID_COLS
+  ) {
+    return { x: lastItemInRow.position.x + lastItemInRow.size.width, y: currentRowY }
+  }
+
+  const maxY = Math.max(
+    ...widgets.map((item) => item.position.y + item.size.height)
+  )
+  return { x: 0, y: Math.max(maxY, headerGridUnits) }
+}


### PR DESCRIPTION
## Summary
- set up Jest with `ts-jest` and testing-library
- extract `findNextPosition` logic into `src/utils/layout.ts`
- update `App.tsx` to use the new helper
- add unit tests for `findNextPosition`
- add `test` script in `package.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684182dbf63483299a13e3f3ae549eed