### PR TITLE
Fix canvas persistence

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ struct Widget {
     position: Position,
     size: Size,
     style: WidgetStyle,
+    created: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -44,6 +45,8 @@ struct CanvasSettings {
     grid_size: i32,
     snap_to_grid: bool,
     zoom_level: f32,
+    header_image: Option<String>,
+    show_header_image: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -70,6 +73,8 @@ impl Default for CanvasData {
                 grid_size: 20,
                 snap_to_grid: false,
                 zoom_level: 1.0,
+                header_image: None,
+                show_header_image: Some(false),
             },
             canvas_size: CanvasSize {
                 width: 1920,


### PR DESCRIPTION
## Summary
- persist `created` on widgets
- persist header image visibility in canvas settings
- update default canvas settings for new fields

## Testing
- `cargo check` *(fails: failed to download from crates.io)*
- `npm run build` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684183202adc8329a2e5519deecd32f0